### PR TITLE
Update Serverless Offline hooks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ class ServerlessOfflineRedisServer {
     this.server = new RedisServer(config);
 
     this.hooks = {
-      'before:offline:start:init': this.openServer.bind(this),
-      'before:offline:start:end': this.closeServer.bind(this),
+      'before:offline:start': this.openServer.bind(this),
+      'before:offline:end': this.closeServer.bind(this),
     };
 
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,10 @@ class ServerlessOfflineRedisServer {
     this.server = new RedisServer(config);
 
     this.hooks = {
+      // backward compatible initialisation
+      'before:offline:start:init': this.openServer.bind(this),
+      'before:offline:start:end': this.closeServer.bind(this),
+      // modern day initialisation
       'before:offline:start': this.openServer.bind(this),
       'before:offline:end': this.closeServer.bind(this),
     };


### PR DESCRIPTION
As per [documentation](https://www.serverless.com/plugins/serverless-offline#usage-and-command-line-options) Serverless Offline is now started using  `serverless offline`. The webhooks have also changed.